### PR TITLE
fix: reload deployment upon config change

### DIFF
--- a/charts/k8s-image-swapper/Chart.yaml
+++ b/charts/k8s-image-swapper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-image-swapper
 description: Mirror images into your own registry and swap image references automatically.
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: 1.0.0
 home: https://github.com/estahn/charts/tree/main/charts/k8s-image-swapper
 keywords:

--- a/charts/k8s-image-swapper/README.md
+++ b/charts/k8s-image-swapper/README.md
@@ -1,6 +1,6 @@
 # k8s-image-swapper
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Mirror images into your own registry and swap image references automatically.
 

--- a/charts/k8s-image-swapper/README.md
+++ b/charts/k8s-image-swapper/README.md
@@ -1,6 +1,6 @@
 # k8s-image-swapper
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Mirror images into your own registry and swap image references automatically.
 
@@ -26,7 +26,7 @@ Mirror images into your own registry and swap image references automatically.
 | config.logFormat | string | `"console"` |  |
 | config.logLevel | string | `"debug"` |  |
 | config.source.filters[0].jmespath | string | `"obj.metadata.namespace == 'kube-system'"` |  |
-| config.target.registry.aws.accountId | string | `"***REMOVED***"` |  |
+| config.target.registry.aws.accountId | int | `12345678` |  |
 | config.target.registry.aws.region | string | `"ap-southeast-2"` |  |
 | config.target.type | string | `"aws"` |  |
 | dev.enabled | bool | `false` |  |

--- a/charts/k8s-image-swapper/templates/deployment.yaml
+++ b/charts/k8s-image-swapper/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
This will ideally be replaced by the app reloading the config without the need to rotate the pod.