### PR TITLE
fix: allow get of serviceaccounts in secret reader clusterrole

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,11 +9,11 @@ changelog:
       labels:
         - Semver-Major
         - breaking-change
-    - title: 🎉 Features 
+    - title: 🎉 Features
       labels:
         - Semver-Minor
         - feature
-    - title: 🐛 Bug Fixes 
+    - title: 🐛 Bug Fixes
       labels:
         - Semver-Minor
         - bugfix

--- a/charts/k8s-image-swapper/Chart.yaml
+++ b/charts/k8s-image-swapper/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
     name: estahn
 annotations:
   artifacthub.io/changes: |
-    - "config.target.aws.accountId changed from integer to string"
+    - "add permissions to ClusterRole to allow reading of service accounts"
   artifacthub.io/images: |
     - name: k8s-image-webhook
       image: ghcr.io/estahn/k8s-image-swapper:1.1.0

--- a/charts/k8s-image-swapper/Chart.yaml
+++ b/charts/k8s-image-swapper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-image-swapper
 description: Mirror images into your own registry and swap image references automatically.
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.1.0
 home: https://github.com/estahn/charts/tree/main/charts/k8s-image-swapper
 keywords:

--- a/charts/k8s-image-swapper/README.md
+++ b/charts/k8s-image-swapper/README.md
@@ -1,6 +1,6 @@
 # k8s-image-swapper
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 Mirror images into your own registry and swap image references automatically.
 

--- a/charts/k8s-image-swapper/templates/clusterrole.yaml
+++ b/charts/k8s-image-swapper/templates/clusterrole.yaml
@@ -21,4 +21,10 @@ rules:
     verbs:
       - watch
       - get
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
 {{- end }}


### PR DESCRIPTION
Addresses #48 

# Tasks

- [x] Bump the chart version (`Chart.yaml` -> `version`)
- [x] JSON Schema updated (`values.schema.json`)
- [x] Update `README.md` via helm-docs
- [x] Update Artifacthub annotation (`Chart.yaml` -> `artifacthub.io/changes`, `artifacthub.io/images`)
