### PR TITLE
ensure the patch jobs have different selector labels

### DIFF
--- a/charts/k8s-image-swapper/templates/_helpers.tpl
+++ b/charts/k8s-image-swapper/templates/_helpers.tpl
@@ -47,7 +47,7 @@ Selector labels
 */}}
 {{- define "k8s-image-swapper.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "k8s-image-swapper.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ .altReleaseName | default .Release.Name }}
 {{- end }}
 
 {{/*

--- a/charts/k8s-image-swapper/templates/job-patch/job-createSecret.yaml
+++ b/charts/k8s-image-swapper/templates/job-patch/job-createSecret.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.patch.enabled }}
+{{ $fullName := include "k8s-image-swapper.fullname" . }}
+{{ $altReleaseName := printf "%s-%s" $fullName "patch-create" }}
+{{- $combineDict := dict "Values" .Values "Chart" .Chart "Release" .Release "altReleaseName" $altReleaseName }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -7,7 +10,7 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "k8s-image-swapper.labels" . | nindent 4 }}
+    {{- include "k8s-image-swapper.labels" $combineDict | nindent 4 }}
 spec:
   {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
   # Alpha feature since k8s 1.12
@@ -15,13 +18,13 @@ spec:
   {{- end }}
   template:
     metadata:
-      name: {{ include "k8s-image-swapper.serviceAccountName" . }}-create
+      name: {{ include "k8s-image-swapper.serviceAccountName" . }}-patch-create
 {{- with .Values.patch.podAnnotations }}
       annotations:
 {{ toYaml .  | indent 8 }}
 {{- end }}
       labels:
-        {{- include "k8s-image-swapper.labels" . | nindent 8 }}
+        {{- include "k8s-image-swapper.labels" $combineDict | nindent 8 }}
     spec:
       {{- if .Values.patch.priorityClassName }}
       priorityClassName: {{ .Values.patch.priorityClassName }}

--- a/charts/k8s-image-swapper/templates/job-patch/job-patchWebhook.yaml
+++ b/charts/k8s-image-swapper/templates/job-patch/job-patchWebhook.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.patch.enabled }}
+{{ $fullName := include "k8s-image-swapper.fullname" . }}
+{{ $altReleaseName := printf "%s-%s" $fullName "patch" }}
+{{- $combineDict := dict "Values" .Values "Chart" .Chart "Release" .Release "altReleaseName" $altReleaseName }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -7,7 +10,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    {{- include "k8s-image-swapper.labels" . | nindent 4 }}
+    {{- include "k8s-image-swapper.labels" $combineDict | nindent 4 }}
 spec:
   {{- if .Capabilities.APIVersions.Has "batch/v1alpha1" }}
   # Alpha feature since k8s 1.12
@@ -21,7 +24,7 @@ spec:
 {{ toYaml .  | indent 8 }}
 {{- end }}
       labels:
-        {{- include "k8s-image-swapper.labels" . | nindent 8 }}
+        {{- include "k8s-image-swapper.labels" $combineDict | nindent 8 }}
     spec:
       {{- if .Values.patch.priorityClassName }}
       priorityClassName: {{ .Values.patch.priorityClassName }}


### PR DESCRIPTION
# Tasks

- [x] Bump the chart version (`Chart.yaml` -> `version`)
- [ ] JSON Schema updated (`values.schema.json`)
- [ ] Update `README.md` via helm-docs
- [ ] Update Artifacthub annotation (`Chart.yaml` -> `artifacthub.io/changes`, `artifacthub.io/images`)

As per:
https://github.com/estahn/k8s-image-swapper/issues/124

A fix.