### PR TITLE
Add the possibility to change the container port

### DIFF
--- a/charts/k8s-image-swapper/Chart.yaml
+++ b/charts/k8s-image-swapper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-image-swapper
 description: Mirror images into your own registry and swap image references automatically.
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: 1.1.0
 home: https://github.com/estahn/charts/tree/main/charts/k8s-image-swapper
 keywords:
@@ -15,7 +15,7 @@ maintainers:
     name: estahn
 annotations:
   artifacthub.io/changes: |
-    - "allow to modify hostnetwork spec definition in deployment"
+    - "allow to modify container port"
   artifacthub.io/images: |
     - name: k8s-image-webhook
       image: ghcr.io/estahn/k8s-image-swapper:1.1.0

--- a/charts/k8s-image-swapper/README.md
+++ b/charts/k8s-image-swapper/README.md
@@ -1,6 +1,6 @@
 # k8s-image-swapper
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 Mirror images into your own registry and swap image references automatically.
 
@@ -28,6 +28,7 @@ Mirror images into your own registry and swap image references automatically.
 | config.source.filters[0].jmespath | string | `"obj.metadata.namespace == 'kube-system'"` |  |
 | config.target.aws.accountId | string | `"12345678"` |  |
 | config.target.aws.region | string | `"ap-southeast-2"` |  |
+| containerPort | int | `8443` |  |
 | dev.enabled | bool | `false` |  |
 | dev.webhookURL | string | `"https://xxx.ngrok.io"` |  |
 | fullnameOverride | string | `""` |  |

--- a/charts/k8s-image-swapper/templates/deployment.yaml
+++ b/charts/k8s-image-swapper/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - --tls-key-file=/usr/local/certificates/key
           ports:
             - name: https
-              containerPort: 8443
+              containerPort: {{ .Values.containerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/k8s-image-swapper/values.schema.json
+++ b/charts/k8s-image-swapper/values.schema.json
@@ -71,6 +71,9 @@
         }
       }
     },
+    "containerPort": {
+      "type": "integer"
+    },
     "dev": {
       "type": "object",
       "properties": {

--- a/charts/k8s-image-swapper/values.yaml
+++ b/charts/k8s-image-swapper/values.yaml
@@ -10,6 +10,8 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+containerPort: 8443
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
# Tasks
Add the possibility to change the container port, it's useful when running pod with hostnetwork: true and the port 8443 is already used by another application on the node.

Default remain unchanged.

- [x] Bump the chart version (`Chart.yaml` -> `version`)
- [x] JSON Schema updated (`values.schema.json`)
- [x] Update `README.md` via helm-docs
- [x] Update Artifacthub annotation (`Chart.yaml` -> `artifacthub.io/changes`, `artifacthub.io/images`)
