### PR TITLE
Add --listen-address flag to set the correct port to listen if setted in values

### DIFF
--- a/charts/k8s-image-swapper/Chart.yaml
+++ b/charts/k8s-image-swapper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-image-swapper
 description: Mirror images into your own registry and swap image references automatically.
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: 1.1.0
 home: https://github.com/estahn/charts/tree/main/charts/k8s-image-swapper
 keywords:
@@ -15,7 +15,7 @@ maintainers:
     name: estahn
 annotations:
   artifacthub.io/changes: |
-    - "allow to modify container port"
+    - "Set --listen-address flag to change port where pod is listening"
   artifacthub.io/images: |
     - name: k8s-image-webhook
       image: ghcr.io/estahn/k8s-image-swapper:1.1.0

--- a/charts/k8s-image-swapper/README.md
+++ b/charts/k8s-image-swapper/README.md
@@ -1,6 +1,6 @@
 # k8s-image-swapper
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 Mirror images into your own registry and swap image references automatically.
 

--- a/charts/k8s-image-swapper/templates/deployment.yaml
+++ b/charts/k8s-image-swapper/templates/deployment.yaml
@@ -54,6 +54,7 @@ spec:
             - --config=/.k8s-image-swapper.yaml
             - --tls-cert-file=/usr/local/certificates/cert
             - --tls-key-file=/usr/local/certificates/key
+            - --listen-address=:{{ .Values.containerPort }}
           ports:
             - name: https
               containerPort: {{ .Values.containerPort }}


### PR DESCRIPTION
If we change the container port k8s image swapper app needs to set a flag to change the listened address.

# Tasks

- [x] Bump the chart version (`Chart.yaml` -> `version`)
- [x] JSON Schema updated (`values.schema.json`)
- [x] Update `README.md` via helm-docs
- [x] Update Artifacthub annotation (`Chart.yaml` -> `artifacthub.io/changes`, `artifacthub.io/images`)
