### PR TITLE
fix: do not create patch serviceaccount when patch is disabled

### DIFF
--- a/charts/k8s-image-swapper/Chart.yaml
+++ b/charts/k8s-image-swapper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-image-swapper
 description: Mirror images into your own registry and swap image references automatically.
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: 1.3.0
 home: https://github.com/estahn/charts/tree/main/charts/k8s-image-swapper
 keywords:
@@ -15,7 +15,7 @@ maintainers:
     name: estahn
 annotations:
   artifacthub.io/changes: |
-    - "Add support of cert-manger to handle TLS certs"
+    - "Do not create patch serviceaccount when patch is disabled"
   artifacthub.io/images: |
     - name: k8s-image-webhook
       image: ghcr.io/estahn/k8s-image-swapper:1.3.0

--- a/charts/k8s-image-swapper/README.md
+++ b/charts/k8s-image-swapper/README.md
@@ -1,6 +1,6 @@
 # k8s-image-swapper
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 Mirror images into your own registry and swap image references automatically.
 

--- a/charts/k8s-image-swapper/templates/job-patch/serviceaccount.yaml
+++ b/charts/k8s-image-swapper/templates/job-patch/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if and .Values.patch.enabled .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Fixes #120 

# Tasks

- [x] Bump the chart version (`Chart.yaml` -> `version`)
- [ ] JSON Schema updated (`values.schema.json`)
- [ ] Update `README.md` via helm-docs
- [x] Update Artifacthub annotation (`Chart.yaml` -> `artifacthub.io/changes`, `artifacthub.io/images`)
