### PR TITLE
fix: deprecated API usage for k8s 1.25+

### DIFF
--- a/charts/k8s-image-swapper/Chart.yaml
+++ b/charts/k8s-image-swapper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-image-swapper
 description: Mirror images into your own registry and swap image references automatically.
 type: application
-version: 1.6.1
+version: 1.6.2
 appVersion: 1.4.1
 home: https://github.com/estahn/charts/tree/main/charts/k8s-image-swapper
 keywords:
@@ -15,7 +15,7 @@ maintainers:
     name: estahn
 annotations:
   artifacthub.io/changes: |
-    - "Allow to set custom name for serviceAccount"
+    - "Fixes deprecated policy api usage for pdb"
   artifacthub.io/images: |
     - name: k8s-image-webhook
       image: ghcr.io/estahn/k8s-image-swapper:1.4.1

--- a/charts/k8s-image-swapper/README.md
+++ b/charts/k8s-image-swapper/README.md
@@ -1,6 +1,6 @@
 # k8s-image-swapper
 
-![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
+![Version: 1.6.2](https://img.shields.io/badge/Version-1.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
 
 Mirror images into your own registry and swap image references automatically.
 
@@ -39,6 +39,7 @@ Mirror images into your own registry and swap image references automatically.
 | image.repository | string | `"ghcr.io/estahn/k8s-image-swapper"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
+| kubeVersionOverride | string | `""` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | patch.enabled | bool | `true` |  |

--- a/charts/k8s-image-swapper/templates/_helpers.tpl
+++ b/charts/k8s-image-swapper/templates/_helpers.tpl
@@ -70,3 +70,21 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the appropriate apiVersion for pod disruption budget
+*/}}
+{{- define "k8s-image-swapper.podDisruptionBudget.apiVersion" -}}
+{{- if semverCompare "<1.21-0" (include "k8s-image-swapper.kubeVersion" $) -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the target Kubernetes version
+*/}}
+{{- define "k8s-image-swapper.kubeVersion" -}}
+  {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride }}
+{{- end -}}

--- a/charts/k8s-image-swapper/templates/pdb.yaml
+++ b/charts/k8s-image-swapper/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ template "k8s-image-swapper.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "k8s-image-swapper.fullname" . }}

--- a/charts/k8s-image-swapper/values.yaml
+++ b/charts/k8s-image-swapper/values.yaml
@@ -12,6 +12,8 @@ image:
 
 containerPort: 8443
 
+kubeVersionOverride: ""
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
for: #126 

# Tasks

- [x] Bump the chart version (`Chart.yaml` -> `version`)
- [ ] JSON Schema updated (`values.schema.json`)
- [x] Update `README.md` via helm-docs
- [x] Update Artifacthub annotation (`Chart.yaml` -> `artifacthub.io/changes`, `artifacthub.io/images`)
