### PR TITLE
feat: add extraEnv for httpbingo chart

### DIFF
--- a/charts/httpbingo/Chart.yaml
+++ b/charts/httpbingo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: httpbingo
 description: A reasonably complete and well-tested golang port of httpbin, with zero dependencies outside the go stdlib.
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: "v2.2.2"
 home: https://github.com/estahn/charts/tree/main/charts/httpbingo
 keywords:

--- a/charts/httpbingo/README.md
+++ b/charts/httpbingo/README.md
@@ -26,6 +26,7 @@ A reasonably complete and well-tested golang port of httpbin, with zero dependen
 | image.repository | string | `"mccutchen/go-httpbin"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
+| extraEnv | object | `{}` | See https://github.com/mccutchen/go-httpbin#configuration |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |

--- a/charts/httpbingo/templates/deployment.yaml
+++ b/charts/httpbingo/templates/deployment.yaml
@@ -33,6 +33,13 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.extraEnv }}
+          env:
+          {{- range $name, $value :=  . }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+          {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/httpbingo/values.yaml
+++ b/charts/httpbingo/values.yaml
@@ -10,6 +10,9 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# See https://github.com/mccutchen/go-httpbin#configuration
+extraEnv: {}
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Purpose

#142 

## Changes

* add `extraEnv` to values. This defaults to `{}`, but allows setting env vars, namely https://github.com/mccutchen/go-httpbin#configuration

## Testing

```
$ helm template . --set extraEnv.FOO=bar | yq '. | select(.kind == "Deployment") | .spec.template.spec.containers[0].env'
- name: FOO
  value: "bar"
```

## Code Author Checklist

- [x] Bump the chart version (`Chart.yaml` -> `version`)
- [x] JSON Schema updated (`values.schema.json`) - :exclamation: n/a, no such file for this chart
- [ ] Update `README.md` via [helm-docs](https://github.com/norwoodj/helm-docs) (or `make prep`)
    - no, I get an error: `make: helm-docs: No such file or directory`
- [x] Run `pre-commit run --all-files` via [pre-commit](https://pre-commit.com/) (or `make prep`)
- [x] Update Artifacthub annotation (`Chart.yaml` -> `artifacthub.io/changes`, `artifacthub.io/images`)
