### PR TITLE
Add ability to specify a priorityClassName for deployment

### DIFF
--- a/charts/k8s-image-swapper/Chart.yaml
+++ b/charts/k8s-image-swapper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-image-swapper
 description: Mirror images into your own registry and swap image references automatically.
 type: application
-version: 1.8.0
+version: 1.9.0
 appVersion: 1.4.1
 home: https://github.com/estahn/charts/tree/main/charts/k8s-image-swapper
 keywords:

--- a/charts/k8s-image-swapper/README.md
+++ b/charts/k8s-image-swapper/README.md
@@ -1,6 +1,6 @@
 # k8s-image-swapper
 
-![Version: 1.10.1](https://img.shields.io/badge/Version-1.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.10](https://img.shields.io/badge/AppVersion-1.5.10-informational?style=flat-square)
+![Version: 1.10.2](https://img.shields.io/badge/Version-1.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.10](https://img.shields.io/badge/AppVersion-1.5.10-informational?style=flat-square)
 
 Mirror images into your own registry and swap image references automatically.
 
@@ -38,6 +38,7 @@ Mirror images into your own registry and swap image references automatically.
 | config.target.aws.region | string | `"ap-southeast-2"` |  |
 | containerPort | int | `8443` |  |
 | deployment.annotations | object | `{}` |  |
+| deployment.priorityClassName | string | `""` |  |
 | dev.enabled | bool | `false` |  |
 | dev.webhookURL | string | `"https://xxx.ngrok.io"` |  |
 | extraEnv | list | `[]` | Additional environment variables to be defined on the container Follows the same syntax as containers.env in a Pod v1 API |

--- a/charts/k8s-image-swapper/templates/deployment.yaml
+++ b/charts/k8s-image-swapper/templates/deployment.yaml
@@ -121,3 +121,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.deployment.priorityClassName }}
+      {{- end }}

--- a/charts/k8s-image-swapper/values.schema.json
+++ b/charts/k8s-image-swapper/values.schema.json
@@ -105,6 +105,9 @@
       "properties": {
         "annotations": {
           "type": "object"
+        },
+        "priorityClassName": {
+          "type": "string"
         }
       }
     },

--- a/charts/k8s-image-swapper/values.yaml
+++ b/charts/k8s-image-swapper/values.yaml
@@ -36,6 +36,7 @@ rbac:
 deployment:
   # Annotations to add to the deployment
   annotations: {}
+  priorityClassName: ""
 
 # If true, create & use Pod Security Policy resources
 # https://kubernetes.io/docs/concepts/policy/pod-security-policy/


### PR DESCRIPTION
## Purpose

Add ability to specify a priorityClassName for deployment

## Changes

If `.Values.deployment.priorityClassName` is specified, set the Deployment to use it.

## Testing

<!-- Please describe how you tested that your change works as expected. -->

## Code Author Checklist

- [x] Bump the chart version (`Chart.yaml` -> `version`)
- [x] JSON Schema updated (`values.schema.json`)
- [x] Update `README.md` via [helm-docs](https://github.com/norwoodj/helm-docs) (or `make prep`)
- [ ] Run `pre-commit run --all-files` via [pre-commit](https://pre-commit.com/) (or `make prep`)
- [ ] Update Artifacthub annotation (`Chart.yaml` -> `artifacthub.io/changes`, `artifacthub.io/images`)
