### PR TITLE
Allow using an existing issuer for cert-manager certificate

### DIFF
--- a/charts/k8s-image-swapper/Chart.yaml
+++ b/charts/k8s-image-swapper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-image-swapper
 description: Mirror images into your own registry and swap image references automatically.
 type: application
-version: 1.9.0
+version: 1.10.0
 appVersion: 1.5.10
 home: https://github.com/estahn/charts/tree/main/charts/k8s-image-swapper
 keywords:
@@ -15,7 +15,7 @@ maintainers:
     name: estahn
 annotations:
   artifacthub.io/changes: |
-    - "Allow test to be optional and specify image for test; fix HPA"
+    - "Allow using an existing issuer for cert-manager certificate"
   artifacthub.io/images: |
     - name: k8s-image-webhook
       image: ghcr.io/estahn/k8s-image-swapper:1.5.10

--- a/charts/k8s-image-swapper/README.md
+++ b/charts/k8s-image-swapper/README.md
@@ -1,6 +1,6 @@
 # k8s-image-swapper
 
-![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.10](https://img.shields.io/badge/AppVersion-1.5.10-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.10](https://img.shields.io/badge/AppVersion-1.5.10-informational?style=flat-square)
 
 Mirror images into your own registry and swap image references automatically.
 
@@ -26,7 +26,8 @@ Mirror images into your own registry and swap image references automatically.
 | awsSecretKeys.secretAccessKey | string | `"aws_secret_access_key"` | If using Hashicorp Vault Operator w/ AWS engine, use `secret_key` |
 | awsSecretName | string | `""` | If set, the secret will be used as environment variables, see awsSecretKeys. |
 | cacheVolume | object | `{"emptyDir":{}}` | The type of volume to be used for caching images |
-| certmanager.enabled | bool | `false` |  |
+| certmanager.enabled | bool | `false` | Should cert-manager be used to issue the certificate use by the k8s-image-swapper endpoints |
+| certmanager.issuerName | string | `nil` | If set, the name of the cert-manager issuer to use to issue the cert, otherwise a self-signed issuer will be created |
 | clusterSuffix | string | `"cluster.local"` | The DNS suffix of cluster addresses |
 | commonLabels | object | `{}` | Labels that will be added on all the resources (not in selectors) |
 | config.dryRun | bool | `true` |  |

--- a/charts/k8s-image-swapper/templates/cert-manager-cert.yaml
+++ b/charts/k8s-image-swapper/templates/cert-manager-cert.yaml
@@ -14,5 +14,5 @@ spec:
     - {{ printf "%s.%s" (include "k8s-image-swapper.fullname" .) .Release.Namespace }}
     - {{ include "k8s-image-swapper.fullname" . }}
   issuerRef:
-    name: {{ include "k8s-image-swapper.fullname" . }}-issuer
+    name: {{ default (printf "%s-%s" (include "k8s-image-swapper.fullname" .) "issuer") .Values.certmanager.issuerName }}
 {{- end -}}

--- a/charts/k8s-image-swapper/templates/cert-manager-issuer.yaml
+++ b/charts/k8s-image-swapper/templates/cert-manager-issuer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certmanager.enabled -}}
+{{- if and .Values.certmanager.enabled (not .Values.certmanager.issuerName) -}}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/charts/k8s-image-swapper/values.schema.json
+++ b/charts/k8s-image-swapper/values.schema.json
@@ -40,13 +40,22 @@
     "awsSecretName": {
       "type": "string"
     },
+    "cacheVolume": {
+      "type": "object"
+    },
     "certmanager": {
       "type": "object",
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "issuerName": {
+          "type": "null"
         }
       }
+    },
+    "clusterSuffix": {
+      "type": "string"
     },
     "commonLabels": {
       "type": "object"
@@ -298,11 +307,20 @@
     "test": {
       "type": "object",
       "properties": {
+        "affinity": {
+          "type": "object"
+        },
         "enabled": {
           "type": "boolean"
         },
         "image": {
           "type": "string"
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "tolerations": {
+          "type": "array"
         }
       }
     },

--- a/charts/k8s-image-swapper/values.yaml
+++ b/charts/k8s-image-swapper/values.yaml
@@ -107,7 +107,10 @@ patch:
 
 # You can use cert-manager to handle TLS cert creation and putting it into webhook cfg
 certmanager:
+  # -- Should cert-manager be used to issue the certificate use by the k8s-image-swapper endpoints
   enabled: false
+  # -- If set, the name of the cert-manager issuer to use to issue the cert, otherwise a self-signed issuer will be created
+  issuerName:
 
 webhook:
   failurePolicy: Ignore


### PR DESCRIPTION
## Purpose

A user may already have an issuer in their cluster that they would like to use instead of the default one created by this chart when cert-manager is enabled.

## Changes

This change adds a value to allow the user to specify the name of an existing issuer to use.

## Code Author Checklist

- [X] Bump the chart version (`Chart.yaml` -> `version`)
- [X] JSON Schema updated (`values.schema.json`)
- [X] Update `README.md` via [helm-docs](https://github.com/norwoodj/helm-docs) (or `make prep`)
- [X] Run `pre-commit run --all-files` via [pre-commit](https://pre-commit.com/) (or `make prep`)
- [X] Update Artifacthub annotation (`Chart.yaml` -> `artifacthub.io/changes`, `artifacthub.io/images`)
