### PR TITLE
bug: Fix bug with wrong type in json schema

### DIFF
--- a/charts/k8s-image-swapper/Chart.yaml
+++ b/charts/k8s-image-swapper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-image-swapper
 description: Mirror images into your own registry and swap image references automatically.
 type: application
-version: 1.10.0
+version: 1.10.1
 appVersion: 1.5.10
 home: https://github.com/estahn/charts/tree/main/charts/k8s-image-swapper
 keywords:
@@ -15,7 +15,7 @@ maintainers:
     name: estahn
 annotations:
   artifacthub.io/changes: |
-    - "Allow using an existing issuer for cert-manager certificate"
+    - "Fix bug in values schema"
   artifacthub.io/images: |
     - name: k8s-image-webhook
       image: ghcr.io/estahn/k8s-image-swapper:1.5.10

--- a/charts/k8s-image-swapper/README.md
+++ b/charts/k8s-image-swapper/README.md
@@ -1,6 +1,6 @@
 # k8s-image-swapper
 
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.10](https://img.shields.io/badge/AppVersion-1.5.10-informational?style=flat-square)
+![Version: 1.10.1](https://img.shields.io/badge/Version-1.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.10](https://img.shields.io/badge/AppVersion-1.5.10-informational?style=flat-square)
 
 Mirror images into your own registry and swap image references automatically.
 
@@ -27,7 +27,7 @@ Mirror images into your own registry and swap image references automatically.
 | awsSecretName | string | `""` | If set, the secret will be used as environment variables, see awsSecretKeys. |
 | cacheVolume | object | `{"emptyDir":{}}` | The type of volume to be used for caching images |
 | certmanager.enabled | bool | `false` | Should cert-manager be used to issue the certificate use by the k8s-image-swapper endpoints |
-| certmanager.issuerName | string | `nil` | If set, the name of the cert-manager issuer to use to issue the cert, otherwise a self-signed issuer will be created |
+| certmanager.issuerName | string | `""` | If set, the name of the cert-manager issuer to use to issue the cert, otherwise a self-signed issuer will be created |
 | clusterSuffix | string | `"cluster.local"` | The DNS suffix of cluster addresses |
 | commonLabels | object | `{}` | Labels that will be added on all the resources (not in selectors) |
 | config.dryRun | bool | `true` |  |

--- a/charts/k8s-image-swapper/values.schema.json
+++ b/charts/k8s-image-swapper/values.schema.json
@@ -50,7 +50,7 @@
           "type": "boolean"
         },
         "issuerName": {
-          "type": "null"
+          "type": "string"
         }
       }
     },

--- a/charts/k8s-image-swapper/values.yaml
+++ b/charts/k8s-image-swapper/values.yaml
@@ -110,7 +110,7 @@ certmanager:
   # -- Should cert-manager be used to issue the certificate use by the k8s-image-swapper endpoints
   enabled: false
   # -- If set, the name of the cert-manager issuer to use to issue the cert, otherwise a self-signed issuer will be created
-  issuerName:
+  issuerName: ""
 
 webhook:
   failurePolicy: Ignore


### PR DESCRIPTION
## Purpose

Sorry, I updated schema after I tested and didn't notice the tool I used to generate it set the type to null for the issuer name.

## Changes

Fix schema type to be string for issuer name.

## Testing

Deployed with updated schema

## Code Author Checklist

- [X] Bump the chart version (`Chart.yaml` -> `version`)
- [X] JSON Schema updated (`values.schema.json`)
- [X] Update `README.md` via [helm-docs](https://github.com/norwoodj/helm-docs) (or `make prep`)
- [X] Run `pre-commit run --all-files` via [pre-commit](https://pre-commit.com/) (or `make prep`)
- [X] Update Artifacthub annotation (`Chart.yaml` -> `artifacthub.io/changes`, `artifacthub.io/images`)
