### PR TITLE
feat: Allow cert-manager certs to be issued by a cluster issuer

### DIFF
--- a/charts/k8s-image-swapper/Chart.yaml
+++ b/charts/k8s-image-swapper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-image-swapper
 description: Mirror images into your own registry and swap image references automatically.
 type: application
-version: 1.10.3
+version: 1.11.0
 appVersion: 1.5.10
 home: https://github.com/estahn/charts/tree/main/charts/k8s-image-swapper
 keywords:
@@ -15,7 +15,7 @@ maintainers:
     name: estahn
 annotations:
   artifacthub.io/changes: |
-    - "Add webhook timeoutSeconds to allow configuration how long the api server should wait for webhook"
+    - "Allow cert-manager certs to be issued by a cluster issuer"
   artifacthub.io/images: |
     - name: k8s-image-webhook
       image: ghcr.io/estahn/k8s-image-swapper:1.5.10

--- a/charts/k8s-image-swapper/README.md
+++ b/charts/k8s-image-swapper/README.md
@@ -1,6 +1,6 @@
 # k8s-image-swapper
 
-![Version: 1.10.3](https://img.shields.io/badge/Version-1.10.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.10](https://img.shields.io/badge/AppVersion-1.5.10-informational?style=flat-square)
+![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.10](https://img.shields.io/badge/AppVersion-1.5.10-informational?style=flat-square)
 
 Mirror images into your own registry and swap image references automatically.
 
@@ -27,6 +27,7 @@ Mirror images into your own registry and swap image references automatically.
 | awsSecretName | string | `""` | If set, the secret will be used as environment variables, see awsSecretKeys. |
 | cacheVolume | object | `{"emptyDir":{}}` | The type of volume to be used for caching images |
 | certmanager.enabled | bool | `false` | Should cert-manager be used to issue the certificate use by the k8s-image-swapper endpoints |
+| certmanager.issuerKind | string | `"Issuer"` | Whether cert-manager should use an Issuer or ClusterIssuer to issue the cert |
 | certmanager.issuerName | string | `""` | If set, the name of the cert-manager issuer to use to issue the cert, otherwise a self-signed issuer will be created |
 | clusterSuffix | string | `"cluster.local"` | The DNS suffix of cluster addresses |
 | commonLabels | object | `{}` | Labels that will be added on all the resources (not in selectors) |

--- a/charts/k8s-image-swapper/templates/cert-manager-cert.yaml
+++ b/charts/k8s-image-swapper/templates/cert-manager-cert.yaml
@@ -14,5 +14,6 @@ spec:
     - {{ printf "%s.%s" (include "k8s-image-swapper.fullname" .) .Release.Namespace }}
     - {{ include "k8s-image-swapper.fullname" . }}
   issuerRef:
+    kind: {{ .Values.certmanager.issuerKind }}
     name: {{ default (printf "%s-%s" (include "k8s-image-swapper.fullname" .) "issuer") .Values.certmanager.issuerName }}
 {{- end -}}

--- a/charts/k8s-image-swapper/values.schema.json
+++ b/charts/k8s-image-swapper/values.schema.json
@@ -49,6 +49,13 @@
         "enabled": {
           "type": "boolean"
         },
+        "issuerKind": {
+          "type": "string",
+          "enum": [
+            "ClusterIssuer",
+            "Issuer"
+          ]
+        },
         "issuerName": {
           "type": "string"
         }

--- a/charts/k8s-image-swapper/values.yaml
+++ b/charts/k8s-image-swapper/values.yaml
@@ -110,6 +110,8 @@ patch:
 certmanager:
   # -- Should cert-manager be used to issue the certificate use by the k8s-image-swapper endpoints
   enabled: false
+  # -- Whether cert-manager should use an Issuer or ClusterIssuer to issue the cert
+  issuerKind: Issuer
   # -- If set, the name of the cert-manager issuer to use to issue the cert, otherwise a self-signed issuer will be created
   issuerName: ""
 


### PR DESCRIPTION
## Purpose

Cert-manager allows both namespaced issuers and cluster level issuers.  Currently the certificate doesn't specify a kind and therefore only uses the default which is a namespaced issuer.  For those that use cluster issuers it would be good to let them specify that.

## Changes

This change allows the user to choose between having an Issuer and a ClusterIssuer for the certificate.  It will still default to Issuer if the user doesn't set the value.

## Code Author Checklist

- [X] Bump the chart version (`Chart.yaml` -> `version`)
- [X] JSON Schema updated (`values.schema.json`)
- [X] Update `README.md` via [helm-docs](https://github.com/norwoodj/helm-docs) (or `make prep`)
- [X] Run `pre-commit run --all-files` via [pre-commit](https://pre-commit.com/) (or `make prep`)
- [X] Update Artifacthub annotation (`Chart.yaml` -> `artifacthub.io/changes`, `artifacthub.io/images`)
