### PR TITLE
chore(docs): Update docs to reflect existence of patch.tolerations

### DIFF
--- a/charts/k8s-image-swapper/Chart.yaml
+++ b/charts/k8s-image-swapper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-image-swapper
 description: Mirror images into your own registry and swap image references automatically.
 type: application
-version: 1.11.0
+version: 1.11.1
 appVersion: 1.5.10
 home: https://github.com/estahn/charts/tree/main/charts/k8s-image-swapper
 keywords:
@@ -15,7 +15,7 @@ maintainers:
     name: estahn
 annotations:
   artifacthub.io/changes: |
-    - "Allow cert-manager certs to be issued by a cluster issuer"
+    - "Update docs to reflect already available tolerations config for patch jobs"
   artifacthub.io/images: |
     - name: k8s-image-webhook
       image: ghcr.io/estahn/k8s-image-swapper:1.5.10

--- a/charts/k8s-image-swapper/README.md
+++ b/charts/k8s-image-swapper/README.md
@@ -1,6 +1,6 @@
 # k8s-image-swapper
 
-![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.10](https://img.shields.io/badge/AppVersion-1.5.10-informational?style=flat-square)
+![Version: 1.11.1](https://img.shields.io/badge/Version-1.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.10](https://img.shields.io/badge/AppVersion-1.5.10-informational?style=flat-square)
 
 Mirror images into your own registry and swap image references automatically.
 
@@ -62,6 +62,7 @@ Mirror images into your own registry and swap image references automatically.
 | patch.podAnnotations | object | `{}` |  |
 | patch.priorityClassName | string | `""` |  |
 | patch.resources | object | `{}` |  |
+| patch.tolerations | list | `[]` |  |
 | pdb.enabled | bool | `false` |  |
 | pdb.minAvailable | string | `"1"` |  |
 | podAnnotations | object | `{}` |  |

--- a/charts/k8s-image-swapper/values.schema.json
+++ b/charts/k8s-image-swapper/values.schema.json
@@ -229,6 +229,9 @@
         },
         "resources": {
           "type": "object"
+        },
+        "tolerations": {
+          "type": "array"
         }
       }
     },

--- a/charts/k8s-image-swapper/values.yaml
+++ b/charts/k8s-image-swapper/values.yaml
@@ -105,6 +105,7 @@ patch:
   podAnnotations: {}
   nodeSelector: {}
   resources: {}
+  tolerations: []
 
 # You can use cert-manager to handle TLS cert creation and putting it into webhook cfg
 certmanager:


### PR DESCRIPTION

## Purpose
Observed today when deploying this that the helm docs nor the values files imply that this is a supported option but it is indeed there inside the patch job definitions.

<!-- Describe the issue this PR is trying to solve.  -->

## Changes
* added patch.tolerations to values.yaml and values.schema.json
* updated Readme

## Testing

<!-- Please describe how you tested that your change works as expected. -->

## Code Author Checklist

- [x] Bump the chart version (`Chart.yaml` -> `version`)
- [x] JSON Schema updated (`values.schema.json`)
- [x] Update `README.md` via [helm-docs](https://github.com/norwoodj/helm-docs) (or `make prep`)
- [x] Run `pre-commit run --all-files` via [pre-commit](https://pre-commit.com/) (or `make prep`)
- [x] Update Artifacthub annotation (`Chart.yaml` -> `artifacthub.io/changes`, `artifacthub.io/images`)
