### PR TITLE
Update service account name on ClusterRoleBinding

### DIFF
--- a/charts/k8s-image-swapper/templates/clusterrolebinding.yaml
+++ b/charts/k8s-image-swapper/templates/clusterrolebinding.yaml
@@ -15,6 +15,6 @@ roleRef:
   name: {{ include "k8s-image-swapper.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "k8s-image-swapper.fullname" . }}
+    name: {{ include "k8s-image-swapper.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}


### PR DESCRIPTION
## Purpose

<!-- Describe the issue this PR is trying to solve.  -->
This solves an issue when you define a custom name for service account which lead us a permission issue to retrieve secrets

## Changes

<!--
> Provide an overview of changes introduced.

* use the same helper function for service account object name in cluster role binding. 
-->

## Testing

<!-- Please describe how you tested that your change works as expected. -->

## Code Author Checklist

- [ ] Bump the chart version (`Chart.yaml` -> `version`)
- [ ] JSON Schema updated (`values.schema.json`)
- [ ] Update `README.md` via [helm-docs](https://github.com/norwoodj/helm-docs) (or `make prep`)
- [ ] Run `pre-commit run --all-files` via [pre-commit](https://pre-commit.com/) (or `make prep`)
- [ ] Update Artifacthub annotation (`Chart.yaml` -> `artifacthub.io/changes`, `artifacthub.io/images`)
